### PR TITLE
Fixes #29, ionItems to work better with Underscore

### DIFF
--- a/components/ionItem/ionItem.js
+++ b/components/ionItem/ionItem.js
@@ -33,7 +33,7 @@ Template.ionItem.helpers({
   },
 
   isAnchor: function () {
-    return !_.isUndefined(this.href) || !_.isUndefined(this.path) || !_.isUndefined(this.url) || !_.isUndefined(this.route);
+    return _.some([this.href,this.path,this.url,this.route],function(path){return path != undefined});
   },
 
   target: function () {
@@ -47,7 +47,7 @@ Template.ionItem.helpers({
 
     if ( this.path || this.url || this.route ) {
 
-      var path = _.find([this.path,this.url,this.route]);
+      var path = _.find([this.path,this.url,this.route],function(path){return path !=undefined});
 
       if ( this.query || this.hash || this.data ){
 


### PR DESCRIPTION
Originally tested with lo-dash, which is smart enough to know what you want if no predicate is defined. Underscore *requires* a predicate which I did not originally include and causes an error.