### PR TITLE
ionPopup implementation

### DIFF
--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -15,7 +15,7 @@
           <div class="popup-buttons">
             {{#each buttons}}
               <button data-action="buttonTapped" data-index="{{index}}"
-              class="button {{#if type}}button-{{type}}{{/if}}">
+              class="button {{type}}">
                 {{{text}}}
               </button>
             {{/each}}

--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -1,22 +1,28 @@
 <template name="ionPopup">
-  <div class="popup-container">
-    <div class="popup">
-      <div class="popup-head">
-        <h3 class="popup-title">{{title}}</h3>
-        {{#if subTitle}}
-          <h5 class="popup-sub-title">{{subTitle}}</h5>
+  <div class="backdrop">
+    <div class="popup-container">
+      <div class="popup">
+        <div class="popup-head">
+          <h3 class="popup-title">{{title}}</h3>
+          {{#if subTitle}}
+            <h5 class="popup-sub-title">{{subTitle}}</h5>
+          {{/if}}
+        </div>
+        <div class="popup-body">
+          {{> UI.contentBlock}}
+        </div>
+        {{#if buttons.length}}
+          <div class="popup-buttons">
+            {{#each buttons}}
+              <button data-action="buttonTapped" data-index="{{index}}"
+              class="button {{#if type}}button-{{type}}{{/if}}">
+                {{{text}}}
+              </button>
+            {{/each}}
+          </div>
         {{/if}}
       </div>
-      <div class="popup-body">
-        {{> UI.contentBlock}}
-      </div>
-      {{#if buttons.count}}
-        <div class="popup-buttons">
-          {{#each buttons}}
-            <button data-action="buttonTapped" class="button {{type}}">{{text}}</button>
-          {{/each}}
-        </div>
-      {{/if}}
     </div>
   </div>
+
 </template>

--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -9,7 +9,7 @@
           {{/if}}
         </div>
         <div class="popup-body">
-          {{> UI.contentBlock}}
+          {{{template}}}
         </div>
         {{#if buttons.length}}
           <div class="popup-buttons">

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -1,21 +1,82 @@
 IonPopup = {
-  show: function () {
+  show: function (options) {
 
+    this.template = Template[options.templateName];
+
+    var buttons = [];
+    for (var i = 0; i < options.buttons.length; i++) {
+      var button = options.buttons[i];
+      buttons.push({
+        text: button.text,
+        type: button.type,
+        index: i
+      });
+    }
+
+    var data = {
+      title: options.title,
+      subTitle: options.subTitle,
+      buttons: buttons
+    };
+
+    console.log(data);
+
+    this.callbacks = {
+      cancel: options.cancel,
+      destructiveButtonClicked: options.destructiveButtonClicked,
+      buttonClicked: options.buttonClicked
+    };
+
+    this.view = Blaze.renderWithData(this.template, data, $('.ionic-body').get(0));
+    $('body').addClass('popup-open');
+
+    var $backdrop = $(this.view.firstNode());
+    $backdrop.addClass('visible active');
+    var $popup = $backdrop.find('.popup-container');
+    $popup.addClass('popup-showing active');
   },
 
   hide: function () {
+    var $backdrop = $(this.view.firstNode());
 
-  },
-
-  alert: function () {
-
-  },
-
-  confirm: function () {
-
-  },
-
-  prompt: function () {
-
+    $popup.removeClass('popup-showing active');
+    $backdrop.removeClass('active visible');
+    Blaze.remove(this.view);
   }
 };
+
+Template.ionPopup.rendered = function () {
+  $(window).on('keyup.ionPopup', function(event) {
+    if (event.which == 27) {
+      IonPopup.hide();
+    }
+  });
+};
+
+Template.ionPopup.destroyed = function () {
+  $(window).off('keyup.ionPopup');
+};
+
+Template.ionPopup.events({
+  // Handle clicking the backdrop
+  'click': function (event, template) {
+    console.log('test');
+    if ($(event.target).hasClass('popup-container')) {
+      IonActionSheet.hide();
+    }
+  },
+
+  'click [data-index]': function (event, template) {
+    var index = $(event.target).data('index');
+    IonPopup.buttonClicked(index);
+  },
+
+  'click [data-destructive]': function (event, template) {
+    IonPopup.destructiveButtonClicked();
+  },
+
+  'click [data-cancel]': function (event, template) {
+    IonPopup.cancel();
+  }
+
+});

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -48,7 +48,7 @@ IonPopup = {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
           onTap: function(event) {
-            options.onOk(event);
+            if (options.onOk) options.onOk(event);
             return true;
           }
         }

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -40,15 +40,15 @@ IonPopup = {
   alert: function (options) {
     IonPopup.show({
       title: options.title,
-      subTitle: options.subtitle,
+      subTitle: options.subTitle,
       template: options.template,
       templateName: options.templateName,
       buttons: [
         {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
-          onTap: function(event) {
-            if (options.onOk) options.onOk(event);
+          onTap: function(event, template) {
+            if (options.onOk) options.onOk(event, template);
             return true;
           }
         }
@@ -59,23 +59,23 @@ IonPopup = {
   confirm: function (options) {
     IonPopup.show({
       title: options.title,
-      subTitle: options.subtitle,
+      subTitle: options.subTitle,
       template: options.template,
       templateName: options.templateName,
       buttons: [
         {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
-          onTap: function (event) {
-            if (options.onOk) options.onOk(event);
+          onTap: function (event, template) {
+            if (options.onOk) options.onOk(event, template);
             return true;
           }
         },
         {
           text: options.cancelText ? options.cancelText : 'Cancel',
           type: options.cancelType ? options.cancelType : 'button-default',
-          onTap: function (event) {
-            if (options.onCancel) options.onCancel(event);
+          onTap: function (event, template) {
+            if (options.onCancel) options.onCancel(event, template);
             return true;
           }
         }
@@ -96,7 +96,7 @@ IonPopup = {
 
     IonPopup.show({
       title: options.title,
-      subTitle: options.subtitle,
+      subTitle: options.subTitle,
       template: template,
       buttons: [
         {
@@ -111,8 +111,8 @@ IonPopup = {
         {
           text: options.cancelText ? options.cancelText : 'Cancel',
           type: options.cancelType ? options.cancelType : 'button-default',
-          onTap: function (event) {
-            if (options.onCancel) options.onCancel(event);
+          onTap: function (event, template) {
+            if (options.onCancel) options.onCancel(event, template);
             return true;
           }
         }

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -37,6 +37,24 @@ IonPopup = {
     $popup.addClass('popup-showing active');
   },
 
+  alert: function (options) {
+    IonPopup.show({
+      title: options.title,
+      subTitle: options.subtitle,
+      template: options.template,
+      templateName: options.templateName,
+      buttons: [
+        {
+          text: options.okText ? options.okText : 'Ok',
+          type: options.okType ? options.okType : 'button-positive',
+          onTap: function() {
+            return true;
+          }
+        }
+      ]
+    });
+  },
+
   close: function () {
     var $backdrop = $(this.view.firstNode());
     var $popup = $backdrop.find('.popup-container');

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -2,8 +2,10 @@ IonPopup = {
   show: function (options) {
 
     this.template = Template[options.templateName];
-
+    this.callbacks = {};
+    this.callbacks.onTap = [];
     var buttons = [];
+
     for (var i = 0; i < options.buttons.length; i++) {
       var button = options.buttons[i];
       buttons.push({
@@ -11,20 +13,13 @@ IonPopup = {
         type: button.type,
         index: i
       });
+      this.callbacks.onTap.push(button.onTap);
     }
 
     var data = {
       title: options.title,
       subTitle: options.subTitle,
       buttons: buttons
-    };
-
-    console.log(data);
-
-    this.callbacks = {
-      cancel: options.cancel,
-      destructiveButtonClicked: options.destructiveButtonClicked,
-      buttonClicked: options.buttonClicked
     };
 
     this.view = Blaze.renderWithData(this.template, data, $('.ionic-body').get(0));
@@ -38,10 +33,22 @@ IonPopup = {
 
   hide: function () {
     var $backdrop = $(this.view.firstNode());
+    var $popup = $backdrop.find('.popup-container');
 
-    $popup.removeClass('popup-showing active');
-    $backdrop.removeClass('active visible');
-    Blaze.remove(this.view);
+    // $popup.removeClass('popup-showing');
+    $popup.addClass('popup-hidden').removeClass('active');
+
+    setTimeout(function(){
+      $('body').removeClass('popup-open');
+      Blaze.remove(this.view);
+    }.bind(this), 100);
+  },
+
+  buttonClicked: function (index, event) {
+    var callbacks = this.callbacks.onTap;
+    if (callbacks[index](event) === true) {
+      IonPopup.hide();
+    }
   }
 };
 
@@ -68,15 +75,7 @@ Template.ionPopup.events({
 
   'click [data-index]': function (event, template) {
     var index = $(event.target).data('index');
-    IonPopup.buttonClicked(index);
-  },
-
-  'click [data-destructive]': function (event, template) {
-    IonPopup.destructiveButtonClicked();
-  },
-
-  'click [data-cancel]': function (event, template) {
-    IonPopup.cancel();
+    IonPopup.buttonClicked(index, event);
   }
 
 });

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -18,7 +18,7 @@ IonPopup = {
     if (options.templateName) {
       innerTemplate = Template[options.templateName].renderFunction().value;
     } else {
-      innerTemplate = options.template;
+      innerTemplate = '<span>' + options.template + '</span>';
     }
 
     var data = {
@@ -66,7 +66,7 @@ IonPopup = {
         {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
-          onTap: function() {
+          onTap: function (event) {
             if (options.onOk) options.onOk(event);
             return true;
           }
@@ -74,7 +74,44 @@ IonPopup = {
         {
           text: options.cancelText ? options.cancelText : 'Cancel',
           type: options.cancelType ? options.cancelType : 'button-default',
-          onTap: function() {
+          onTap: function (event) {
+            if (options.onCancel) options.onCancel(event);
+            return true;
+          }
+        }
+      ]
+    });
+  },
+
+  prompt: function (options) {
+
+    if (options.templateName) {
+      template = Template[options.templateName].renderFunction().value;
+    } else {
+      template = '<span>' + options.template + '</span>';
+    }
+
+    template += '<input type="' + options.inputType + '" placeholder="' +
+      options.inputPlaceholder + '" name="prompt" >';
+
+    IonPopup.show({
+      title: options.title,
+      subTitle: options.subtitle,
+      template: template,
+      buttons: [
+        {
+          text: options.okText ? options.okText : 'Ok',
+          type: options.okType ? options.okType : 'button-positive',
+          onTap: function (event, template) {
+            var inputVal = $(template.firstNode).find('[name=prompt]').val();
+            if (options.onOk) options.onOk(event, inputVal);
+            return true;
+          }
+        },
+        {
+          text: options.cancelText ? options.cancelText : 'Cancel',
+          type: options.cancelType ? options.cancelType : 'button-default',
+          onTap: function (event) {
             if (options.onCancel) options.onCancel(event);
             return true;
           }
@@ -94,10 +131,10 @@ IonPopup = {
     }.bind(this), 100);
   },
 
-  buttonClicked: function (index, event) {
+  buttonClicked: function (index, event, template) {
     var callback = this.buttons[index].onTap;
     if(callback){
-      if (callback(event) === true) {
+      if (callback(event, template) === true) {
         IonPopup.close();
       }
     }
@@ -126,7 +163,7 @@ Template.ionPopup.events({
 
   'click [data-index]': function (event, template) {
     var index = $(event.target).data('index');
-    IonPopup.buttonClicked(index, event);
+    IonPopup.buttonClicked(index, event, template);
   }
 
 });

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -1,25 +1,31 @@
 IonPopup = {
   show: function (options) {
-
-    this.template = Template[options.templateName];
-    this.callbacks = {};
-    this.callbacks.onTap = [];
-    var buttons = [];
+    this.template = Template.ionPopup;
+    this.buttons = [];
+    var innerTemplate;
 
     for (var i = 0; i < options.buttons.length; i++) {
       var button = options.buttons[i];
-      buttons.push({
+      this.buttons.push({
         text: button.text,
         type: button.type,
-        index: i
+        index: i,
+        onTap: button.onTap
       });
-      this.callbacks.onTap.push(button.onTap);
+    }
+
+    //Figure out if a template or just a html string was passed
+    if (options.templateName) {
+      innerTemplate = Template[options.templateName].renderFunction().value;
+    } else {
+      innerTemplate = options.template;
     }
 
     var data = {
       title: options.title,
       subTitle: options.subTitle,
-      buttons: buttons
+      buttons: this.buttons,
+      template: innerTemplate
     };
 
     this.view = Blaze.renderWithData(this.template, data, $('.ionic-body').get(0));
@@ -31,23 +37,23 @@ IonPopup = {
     $popup.addClass('popup-showing active');
   },
 
-  hide: function () {
+  close: function () {
     var $backdrop = $(this.view.firstNode());
     var $popup = $backdrop.find('.popup-container');
-
-    // $popup.removeClass('popup-showing');
     $popup.addClass('popup-hidden').removeClass('active');
 
-    setTimeout(function(){
+    setTimeout(function () {
       $('body').removeClass('popup-open');
       Blaze.remove(this.view);
     }.bind(this), 100);
   },
 
   buttonClicked: function (index, event) {
-    var callbacks = this.callbacks.onTap;
-    if (callbacks[index](event) === true) {
-      IonPopup.hide();
+    var callback = this.buttons[index].onTap;
+    if(callback){
+      if (callback(event) === true) {
+        IonPopup.close();
+      }
     }
   }
 };
@@ -55,7 +61,7 @@ IonPopup = {
 Template.ionPopup.rendered = function () {
   $(window).on('keyup.ionPopup', function(event) {
     if (event.which == 27) {
-      IonPopup.hide();
+      IonPopup.close();
     }
   });
 };
@@ -67,9 +73,8 @@ Template.ionPopup.destroyed = function () {
 Template.ionPopup.events({
   // Handle clicking the backdrop
   'click': function (event, template) {
-    console.log('test');
     if ($(event.target).hasClass('popup-container')) {
-      IonActionSheet.hide();
+      IonPopup.close();
     }
   },
 

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -47,7 +47,35 @@ IonPopup = {
         {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
+          onTap: function(event) {
+            options.onOk(event);
+            return true;
+          }
+        }
+      ]
+    });
+  },
+
+  confirm: function (options) {
+    IonPopup.show({
+      title: options.title,
+      subTitle: options.subtitle,
+      template: options.template,
+      templateName: options.templateName,
+      buttons: [
+        {
+          text: options.okText ? options.okText : 'Ok',
+          type: options.okType ? options.okType : 'button-positive',
           onTap: function() {
+            if (options.onOk) options.onOk(event);
+            return true;
+          }
+        },
+        {
+          text: options.cancelText ? options.cancelText : 'Cancel',
+          type: options.cancelType ? options.cancelType : 'button-default',
+          onTap: function() {
+            if (options.onCancel) options.onCancel(event);
             return true;
           }
         }


### PR DESCRIPTION
I implemented ionPopup with all it's functionalities (show, alert, prompt, confirm). I tried to copy the API from Ionic as far as possible. However, I used callbacks (onOk, onCancel) instead of promises for the buttons on alerts etc.. Like in the original you can either pass in a template-string via the option template or the name of a template. I use the option templateName instead of templateUrl because I thought it fits better with Meteor.
I'm happy about any feedback on my implementation.

Example for confirm popup:
```
IonPopup.confirm({
  title: 'Confirm',
  subTitle: 'You should confirm this!',
  templateName: 'confirmPopup',
  onOk: function() {
    console.log('confirmed');
  },
  onCancel: function () {
    console.log('cancel'):
  }
});
```