### PR TITLE
Added badge color option to ionTab

### DIFF
--- a/components/ionTab/ionTab.html
+++ b/components/ionTab/ionTab.html
@@ -11,7 +11,7 @@
     {{title}}
 
     {{#if badgeNumber}}
-      <div class="badge badge-assertive">
+      <div class="badge badge-{{badgeColor}}">
         {{badgeNumber}}
       </div>
     {{/if}}

--- a/components/ionTab/ionTab.js
+++ b/components/ionTab/ionTab.js
@@ -66,5 +66,9 @@ Template.ionTab.helpers({
 
   badgeNumber: function () {
     return this.badgeNumber;
+  },
+
+  badgeColor: function () {
+    return this.badgeColor||'assertive';
   }
 });


### PR DESCRIPTION
This adds the 'badgeColor' argument in case you want to change the badge's color class (e.g positive, energized, etc).