### PR TITLE
Fix KeyboardShow Scroll, covering elements at bottom and White space on hide keboard issues

### DIFF
--- a/components/ionKeyboard/ionKeyboard.js
+++ b/components/ionKeyboard/ionKeyboard.js
@@ -39,6 +39,14 @@ IonKeyboard = {
     if (Meteor.isCordova) {
       cordova.plugins.Keyboard.disableScroll(false);
     }
+  },
+  scrollTo: function(elem, speed) {
+    var scrollArea = $(".content.overflow-scroll");
+    // scroll animation needs to be >0 so that it can scroll while the keyboard is opening...
+    scrollArea.animate({
+        scrollTop:  scrollArea.scrollTop() - scrollArea.offset().top + $(elem).offset().top - 10
+    }, speed == undefined ? 200 : speed);
+
   }
 };
 
@@ -46,6 +54,14 @@ window.addEventListener('native.keyboardshow', function (event) {
   // TODO: Android is having problems
   if (Platform.isAndroid()) {
     return;
+  }
+
+  console.log("Keyboard Open "+event.keyboardHeight);
+
+  var currentElement = document.activeElement;
+
+  if ( $(currentElement).is('input,textarea,select') ) {
+    IonKeyboard.scrollTo(currentElement);
   }
 
   $('body').addClass('keyboard-open');
@@ -63,12 +79,6 @@ window.addEventListener('native.keyboardshow', function (event) {
     $(el).css({bottom: keyboardHeight});
   });
 
-  $('.content.overflow-scroll').on('focus', 'input,textarea', function(event) {
-    var contentOffset = $(event.delegateTarget).offset().top;
-    var padding = 10;
-    var scrollTo = $(event.delegateTarget).scrollTop() + $(this).offset().top - (contentOffset + padding);
-    $(event.delegateTarget).scrollTop(scrollTo);
-  });
 });
 
 window.addEventListener('native.keyboardhide', function (event) {
@@ -76,7 +86,9 @@ window.addEventListener('native.keyboardhide', function (event) {
   if (Platform.isAndroid()) {
     return;
   }
-  
+
+  console.log("Keyboard Closed");
+
   $('body').removeClass('keyboard-open');
 
   // Detach any elements that were attached

--- a/components/ionKeyboard/ionKeyboard.js
+++ b/components/ionKeyboard/ionKeyboard.js
@@ -56,10 +56,11 @@ window.addEventListener('native.keyboardshow', function (event) {
     return;
   }
 
-  console.log("Keyboard Open "+event.keyboardHeight);
+  //console.log("Keyboard Open "+event.keyboardHeight);
 
   var currentElement = document.activeElement;
 
+  // If the current focused element is an input, textarea or select, scroll to it.
   if ( $(currentElement).is('input,textarea,select') ) {
     IonKeyboard.scrollTo(currentElement);
   }
@@ -87,7 +88,7 @@ window.addEventListener('native.keyboardhide', function (event) {
     return;
   }
 
-  console.log("Keyboard Closed");
+  //console.log("Keyboard Closed");
 
   $('body').removeClass('keyboard-open');
 


### PR DESCRIPTION
Was having a few issues with the keyboard opening over the focused element as well the whitespace being left on the body for keyboard spacing after it closed, also wasn't focusing for select boxes. This seems to solve that.

This PR monitors the active selected field on `native.keyboardshow` and if it is an `input`, `textarea` or `select` element, scrolls to it with a 200ms delay to ensure it accounts for the keyboard opening.

**HANDY NOTE:** if you are defining classes on a `{{ionContent}}` block ,ensure you have `content` in there as well as your other classes as the `ionKeyboard` functions rely on the `.content.overflow-scroll` class which was the first issue i was encountering.

It has solved my issues I was having, and hopefully will be useful for others also :)