### PR TITLE
Added title parameter to ionView

### DIFF
--- a/components/ionView/ionView.html
+++ b/components/ionView/ionView.html
@@ -1,4 +1,10 @@
 <template name="ionView">
+  {{#if title}}
+    {{#contentFor "headerTitle"}}
+      <h1 class="title">{{title}}</h1>
+    {{/contentFor}}
+  {{/if}}
+
   <div class="{{classes}}">
     {{> UI.contentBlock}}
   </div>

--- a/components/ionView/ionView.js
+++ b/components/ionView/ionView.js
@@ -19,5 +19,10 @@ Template.ionView.helpers({
     }
 
     return classes.join(' ');
+  },
+  title: function () {
+    if ( Template.instance().data && Template.instance().data.title ) {
+      return this.title;
+    }
   }
 });


### PR DESCRIPTION
Added a convenience parameter to `ionView`, allowing you to create a standard title without having to call `contentFor`. Example:

```html
<template name="profile">
	{{#contentFor "headerTitle"}}
		<h1 class="title">"Profile"</h1>
	{{/contentFor}}

	{{#ionView}}
		{{#ionContent}}
			<h1>Welcome on your profile.</h1>
		{{/ionContent}}
	{{/ionView}}
</template>
```

Can become:

```html
<template name="profile">
	{{#ionView title="Profile"}}
		{{#ionContent}}
			<h1>Welcome on your profile.</h1>
		{{/ionContent}}
	{{/ionView}}
</template>
```