### PR TITLE
IonScrollPositions based on route path rather than route name

### DIFF
--- a/components/ionNavBackButton/ionNavBackButton.js
+++ b/components/ionNavBackButton/ionNavBackButton.js
@@ -1,7 +1,7 @@
 IonScrollPositions = {};
 
 Router.onStop(function () {
-  IonScrollPositions[Router.current().route.getName()] = $('.overflow-scroll').scrollTop();
+  IonScrollPositions[this.route.path(this.params)] = $('.overflow-scroll').scrollTop();
 });
 
 Template.ionNavBackButton.events({

--- a/components/ionView/ionView.js
+++ b/components/ionView/ionView.js
@@ -3,10 +3,10 @@ Template.ionView.rendered = function () {
   IonNavigation.skipTransitions = false;
 
   // Reset our scroll position
-  var routeName = Router.current().route.getName();
-  if(IonScrollPositions[routeName]) {
-    $('.overflow-scroll').scrollTop(IonScrollPositions[routeName]);
-    delete IonScrollPositions[routeName];
+  var routePath = Router.current().route.path(Router.current().params);
+  if(IonScrollPositions[routePath]) {
+    $('.overflow-scroll').scrollTop(IonScrollPositions[routePath]);
+    delete IonScrollPositions[routePath];
   }
 };
 


### PR DESCRIPTION
Hi,

Firstly, great project - thanks a lot for the time this must have taken!

I noticed a small bug with the Meteor Hunt demo that I've tried to fix in this pull request.

The bug:

1. Load the Meteor Hunt trending list
2. Select a product
3. Scroll a random distance down the page
4. Return to the trending list
5. Select a different product
6. Your scroll position on the new product page is the same as on the previous product page

This is because the scroll position is saved against the routeName which doesn't account for the fact that the route might be dynamic with parameters (in the case of Meteor Hunt, the product route has an _id parameter)

This pull request switches from using the route name to the route path which includes any parameters in the URL.

Hopefully its of some use!