### PR TITLE
Update ionTabs.js

### DIFF
--- a/components/ionTabs/ionTabs.js
+++ b/components/ionTabs/ionTabs.js
@@ -31,11 +31,11 @@ Template.ionTabs.helpers({
       classes.push(this.class);
     }
 
-    if (this.style === 'android') {
+    if (this.style === 'android' || ( !this.style && Platform.isAndroid()) ) {
       classes.push('tabs-top tabs-striped tabs-icon-left');
     }
 
-    if (this.style === 'ios') {
+    if (this.style === 'ios' || ( !this.style && Platform.isIOS()) ) {
       classes.push('tabs-icon-top');
     }
 


### PR DESCRIPTION
According to Ionic documentation:
>For iOS, tabs will appear at the bottom of the screen. For Android, tabs will be at the top of the screen, below the nav-bar."

[ http://ionicframework.com/docs/api/directive/ionTabs/ ]

This change makes meteoric more consistent with Ionic making the UX closer to the native one.
This behavior can be prevented by passing any string to the style attribute, e.g. style="none", like in Ionic $ionicConfigProvider
[ http://ionicframework.com/docs/api/provider/$ionicConfigProvider/#views.transition ]