### PR TITLE
fixed a bug in ionTab

### DIFF
--- a/components/ionTab/ionTab.js
+++ b/components/ionTab/ionTab.js
@@ -28,7 +28,7 @@ Template.ionTab.helpers({
     }
 
     if (this.path && Router.routes[this.path]) {
-      return Router.routes[this.path].path(Template.parentData(1));
+      return Router.routes[this.path].path(Template.currentData());
     }
   },
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "meteoric:ionic",
   summary: "Ionic components for Meteor. No Angular!",
-  version: "0.1.17",
+  version: "0.1.18",
   git: "https://github.com/meteoric/meteor-ionic.git"
 });
 


### PR DESCRIPTION
Using currentData instead of parentData. Not sure why parentData was being used.

If you have a route as follows:
```
{{> ionTab title="Team" path='team' _id=teamId iconOff="tshirt-outline" iconOn="tshirt" class="tab-item-positive"}}
```
then you want the _id of the current field, and not the _id of the parent that could be something completely different or not even exist. Using parentData make passing _id in the above line useless.