### PR TITLE
Only scroll entering nav view, not the one you're leaving.

### DIFF
--- a/components/ionView/ionView.js
+++ b/components/ionView/ionView.js
@@ -5,7 +5,7 @@ Template.ionView.rendered = function () {
   // Reset our scroll position
   var routePath = Router.current().route.path(Router.current().params);
   if(IonScrollPositions[routePath]) {
-    $('.overflow-scroll').scrollTop(IonScrollPositions[routePath]);
+    $('.overflow-scroll').not('.nav-view-leaving .overflow-scroll').scrollTop(IonScrollPositions[routePath]);
     delete IonScrollPositions[routePath];
   }
 };


### PR DESCRIPTION
If you had already been to a page previously, and then navigated away from it, there was a flash of it's previous scroll position that showed.  This ensures that only the view that is being animated in to view, is scrolled to the correct position, and the one leaving the view is left alone.