### PR TITLE
Session set `hasTabsTop` to true when Platform is Android

### DIFF
--- a/components/ionTabs/ionTabs.js
+++ b/components/ionTabs/ionTabs.js
@@ -3,7 +3,7 @@ Template.ionTabs.created = function () {
 };
 
 Template.ionTabs.rendered = function () {
-  if ((this.data.class && this.data.class === 'tabs-top') || this.data.style === 'android') {
+  if ((this.data.class && this.data.class === 'tabs-top') || this.data.style === 'android' || ( !this.data.style && Platform.isAndroid())) {
     Session.set('hasTabsTop', true);
   } else {
     Session.set('hasTabs', true);


### PR DESCRIPTION
Since the `tabs-top` class can be set based on the Platform in the helper then the  `Session.get('hasTabsTop')` needs to be set properly.