### PR TITLE
Top ionTabs with multiple CSS classes doesn't add 'has-tabs-top' to the content

### DIFF
--- a/components/ionTabs/ionTabs.js
+++ b/components/ionTabs/ionTabs.js
@@ -3,7 +3,7 @@ Template.ionTabs.created = function () {
 };
 
 Template.ionTabs.rendered = function () {
-  if ((this.data.class && this.data.class === 'tabs-top') || this.data.style === 'android' || ( !this.data.style && Platform.isAndroid())) {
+  if ((this.data.class && this.data.class.indexOf('tabs-top') > -1) || this.data.style === 'android' || ( !this.data.style && Platform.isAndroid())) {
     Session.set('hasTabsTop', true);
   } else {
     Session.set('hasTabs', true);


### PR DESCRIPTION
When adding multiple CSS classes to a 'tabs-top' ionTabs, the content won't get the 'has-tabs-top' CSS class.

Example:
```
{{#ionTabs class="tabs-top"}}
```
Will add 'has-tabs-top' to the content div, the content will be full-height.

```
{{#ionTabs class="tabs-top tabs-positive"}}
```
Won't add 'has-tabs-top' to the content div, an empty space will be shown at the bottom of the page.