### PR TITLE
Cleaned up popups

### DIFF
--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -2,14 +2,16 @@
   <div class="backdrop">
     <div class="popup-container">
       <div class="popup">
-        <div class="popup-head">
-          {{#if title}}
-            <h3 class="popup-title">{{title}}</h3>
-          {{/if}}
-          {{#if subTitle}}
-            <h5 class="popup-sub-title">{{subTitle}}</h5>
-          {{/if}}
-        </div>
+        {{#if hasHead}}
+          <div class="popup-head">
+            {{#if title}}
+              <h3 class="popup-title">{{title}}</h3>
+            {{/if}}
+            {{#if subTitle}}
+              <h5 class="popup-sub-title">{{subTitle}}</h5>
+            {{/if}}
+          </div>
+        {{/if}}
         {{#if template}}
           <div class="popup-body">
             {{{template}}}

--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -3,14 +3,18 @@
     <div class="popup-container">
       <div class="popup">
         <div class="popup-head">
-          <h3 class="popup-title">{{title}}</h3>
+          {{#if title}}
+            <h3 class="popup-title">{{title}}</h3>
+          {{/if}}
           {{#if subTitle}}
             <h5 class="popup-sub-title">{{subTitle}}</h5>
           {{/if}}
         </div>
-        <div class="popup-body">
-          {{{template}}}
-        </div>
+        {{#if template}}
+          <div class="popup-body">
+            {{{template}}}
+          </div>
+        {{/if}}
         {{#if buttons.length}}
           <div class="popup-buttons">
             {{#each buttons}}

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -64,18 +64,18 @@ IonPopup = {
       templateName: options.templateName,
       buttons: [
         {
-          text: options.okText ? options.okText : 'Ok',
-          type: options.okType ? options.okType : 'button-positive',
-          onTap: function (event, template) {
-            if (options.onOk) options.onOk(event, template);
-            return true;
-          }
-        },
-        {
           text: options.cancelText ? options.cancelText : 'Cancel',
           type: options.cancelType ? options.cancelType : 'button-default',
           onTap: function (event, template) {
             if (options.onCancel) options.onCancel(event, template);
+            return true;
+          }
+        },
+        {
+          text: options.okText ? options.okText : 'Ok',
+          type: options.okType ? options.okType : 'button-positive',
+          onTap: function (event, template) {
+            if (options.onOk) options.onOk(event, template);
             return true;
           }
         }
@@ -101,19 +101,19 @@ IonPopup = {
       template: template,
       buttons: [
         {
+          text: options.cancelText ? options.cancelText : 'Cancel',
+          type: options.cancelType ? options.cancelType : 'button-default',
+          onTap: function (event, template) {
+            if (options.onCancel) options.onCancel(event, template);
+            return true;
+          }
+        },
+        {
           text: options.okText ? options.okText : 'Ok',
           type: options.okType ? options.okType : 'button-positive',
           onTap: function (event, template) {
             var inputVal = $(template.firstNode).find('[name=prompt]').val();
             if (options.onOk) options.onOk(event, inputVal);
-            return true;
-          }
-        },
-        {
-          text: options.cancelText ? options.cancelText : 'Cancel',
-          type: options.cancelType ? options.cancelType : 'button-default',
-          onTap: function (event, template) {
-            if (options.onCancel) options.onCancel(event, template);
             return true;
           }
         }
@@ -167,4 +167,10 @@ Template.ionPopup.events({
     IonPopup.buttonClicked(index, event, template);
   }
 
+});
+
+Template.ionPopup.helpers({
+  hasHead: function() {
+    return this.title || this.subTitle;
+  }
 });

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -13,8 +13,8 @@ IonPopup = {
       });
     }
 
-    //Figure out if a template or just a html string was passed
-    var innerTemplate;
+    // Figure out if a template or just a html string was passed
+    var innerTemplate = '';
     if (options.templateName) {
       innerTemplate = Template[options.templateName].renderFunction().value;
     } else if (options.template) {
@@ -85,13 +85,15 @@ IonPopup = {
 
   prompt: function (options) {
 
-    var template;
+    var template = '';
     if (options.templateName) {
       template = Template[options.templateName].renderFunction().value;
     } else if (options.template) {
-      template = '<span>' + options.template + '</span>';
+      template = '<span class="popup-prompt-text">' + options.template + '</span>';
     }
 
+    options.inputType = options.inputType || 'text';
+    options.inputPlaceholder = options.inputPlaceholder || '';
     template += '<input type="' + options.inputType + '" placeholder="' +
       options.inputPlaceholder + '" name="prompt" >';
 

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -17,7 +17,7 @@ IonPopup = {
     //Figure out if a template or just a html string was passed
     if (options.templateName) {
       innerTemplate = Template[options.templateName].renderFunction().value;
-    } else {
+    } else if (options.template) {
       innerTemplate = '<span>' + options.template + '</span>';
     }
 

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -2,7 +2,6 @@ IonPopup = {
   show: function (options) {
     this.template = Template.ionPopup;
     this.buttons = [];
-    var innerTemplate;
 
     for (var i = 0; i < options.buttons.length; i++) {
       var button = options.buttons[i];
@@ -15,6 +14,7 @@ IonPopup = {
     }
 
     //Figure out if a template or just a html string was passed
+    var innerTemplate;
     if (options.templateName) {
       innerTemplate = Template[options.templateName].renderFunction().value;
     } else if (options.template) {
@@ -85,9 +85,10 @@ IonPopup = {
 
   prompt: function (options) {
 
+    var template;
     if (options.templateName) {
       template = Template[options.templateName].renderFunction().value;
-    } else {
+    } else if (options.template) {
       template = '<span>' + options.template + '</span>';
     }
 

--- a/package.js
+++ b/package.js
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
     "iron:router@1.0.0",
     "tracker",
     "session",
-    "jquery"
+    "jquery",
   ], "client");
 
   api.addFiles([
@@ -117,7 +117,8 @@ Package.onUse(function(api) {
     "components/ionTab/ionTab.js",
 
     "components/ionView/ionView.html",
-    "components/ionView/ionView.js"
+    "components/ionView/ionView.js",
+
   ], "client");
 
   api.export("Platform");

--- a/package.js
+++ b/package.js
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
     "iron:router@1.0.0",
     "tracker",
     "session",
-    "jquery",
+    "jquery"
   ], "client");
 
   api.addFiles([
@@ -117,7 +117,7 @@ Package.onUse(function(api) {
     "components/ionTab/ionTab.js",
 
     "components/ionView/ionView.html",
-    "components/ionView/ionView.js",
+    "components/ionView/ionView.js"
 
   ], "client");
 


### PR DESCRIPTION
- Allow popups with no header or no body
- Reordered buttons to get "cancel" actions on the left (common on [iOS](https://www.google.fr/search?q=ios8+popup+dialog&source=lnms&tbm=isch&sa=X&ved=0CAcQ_AUoAWoVChMI3cWoz8uhxwIVC50aCh3ccQdW&biw=1397&bih=661) and [Android](https://www.google.fr/search?q=android+lollipop+popup+dialog&espv=2&biw=1397&bih=661&source=lnms&tbm=isch&sa=X&ved=0CAYQ_AUoAWoVChMIsrXi2suhxwIVynAaCh3hBQNX) latest versions)