### PR TITLE
backdropClickToClose option on ionModal

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -370,6 +370,13 @@ If you'd like to have another element dismiss the modal, add `data-dismiss=modal
 </button>
 ```
 
+To prevent a click outside the modal closing it, pass false to `backdropClickToClose`. For example :
+```
+{{#ionModal title="My Modal" backdropClickToClose=false}}
+    <p>My modal content goes here</p>
+{{/ionModal}}
+```
+
 ## Popups
 
 You show alerts using the `ionPopup` component. This can be done as follows:

--- a/components/ionModal/ionModal.js
+++ b/components/ionModal/ionModal.js
@@ -87,6 +87,7 @@ Template.ionModal.created = function () {
   this.title = this.data.closeText;
   this.focusFirstInput = _.isUndefined(this.data.focusFirstInput) ? true : this.data.focusFirstInput;
   this.animation = this.data.animation || 'slide-in-up';
+  this.backdropClickToClose = _.isUndefined(this.data.backdropClickToClose) || this.data.backdropClickToClose !== false;
 };
 
 Template.ionModal.rendered = function () {
@@ -159,7 +160,9 @@ Template.ionModal.events({
   // Handle clicking the backdrop
   'click': function (event, template) {
     if ($(event.target).hasClass('modal-backdrop')) {
-      IonModal.close();
+      if (template.backdropClickToClose) {
+        IonModal.close();
+      }
     }
   },
   'click [data-dismiss=modal]': function (event, template) {


### PR DESCRIPTION
Hi,

I've added the option `backdropClickToClose` to the `ionModal`. It's in the Ionic documentation as a property of the options object on initialise.

http://ionicframework.com/docs/api/controller/ionicModal/

I've put in a brief note and example in the guide. 

Apologies if this has been already implemented, I just couldn't find it.

Thanks,

Alex
