### PR TITLE
Fix iOS9 switching between text inputs keyboard issue

### DIFF
--- a/components/ionKeyboard/ionKeyboard.js
+++ b/components/ionKeyboard/ionKeyboard.js
@@ -7,43 +7,42 @@ Meteor.startup(function () {
 IonKeyboard = {
   close: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.close();
+      Keyboard.hide();
     }
   },
 
   show: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.show();
+      Keyboard.show();
     }
   },
 
   hideKeyboardAccessoryBar: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);
+      Keyboard.hideFormAccessoryBar(true);
     }
   },
 
   showKeyboardAccessoryBar: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.hideKeyboardAccessoryBar(false);
+      Keyboard.hideFormAccessoryBar(false);
     }
   },
 
   disableScroll: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.disableScroll(true);
+      Keyboard.disableScrollingInShrinkView(true);
     }
   },
 
   enableScroll: function () {
     if (Meteor.isCordova) {
-      cordova.plugins.Keyboard.disableScroll(false);
+      Keyboard.disableScrollingInShrinkView(false);
     }
   }
 };
 
-window.addEventListener('native.keyboardshow', function (event) {
-
+window.addEventListener('keyboardHeightWillChange', function (event) {
   // TODO: Android is having problems
   if (Platform.isAndroid()) {
     return;
@@ -52,24 +51,12 @@ window.addEventListener('native.keyboardshow', function (event) {
   $('body').addClass('keyboard-open');
   var keyboardHeight = event.keyboardHeight;
 
-  // Attach any elements that want to be attached
-  $('[data-keyboard-attach]').each(function (index, el) {
-    $(el).data('ionkeyboard.bottom', $(el).css('bottom'));
-    $(el).css({bottom: keyboardHeight});
-  });
-
-  // Move the bottom of the content area(s) above the top of the keyboard
-  $('.content.overflow-scroll').each(function (index, el) {
-    $(el).data('ionkeyboard.bottom', $(el).css('bottom'));
-    $(el).css({bottom: keyboardHeight});
-  });
-
   // Scroll to the focused element
   scrollToFocusedElement(null, keyboardHeight);
 
 });
 
-window.addEventListener('native.keyboardhide', function (event) {
+window.addEventListener('keyboardDidHide', function (event) {
 
   // TODO: Android is having problems
   if (Platform.isAndroid()) {
@@ -78,15 +65,5 @@ window.addEventListener('native.keyboardhide', function (event) {
 
   // $('input, textarea').blur();
   $('body').removeClass('keyboard-open');
-
-  // Detach any elements that were attached
-  $('[data-keyboard-attach]').each(function (index, el) {
-    $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
-  });
-
-  // Reset the content area(s)
-  $('.content.overflow-scroll').each(function (index, el) {
-    $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
-  });
 
 });

--- a/components/ionKeyboard/ionKeyboard.js
+++ b/components/ionKeyboard/ionKeyboard.js
@@ -42,12 +42,15 @@ IonKeyboard = {
   }
 };
 
-window.addEventListener('native.keyboardshow', function (event) {
+var keyboardHideTimeout = 0;
 
+window.addEventListener('native.keyboardshow', function (event) {
   // TODO: Android is having problems
   if (Platform.isAndroid()) {
     return;
   }
+
+  clearTimeout(keyboardHideTimeout);
 
   $('body').addClass('keyboard-open');
   var keyboardHeight = event.keyboardHeight;
@@ -70,23 +73,26 @@ window.addEventListener('native.keyboardshow', function (event) {
 });
 
 window.addEventListener('native.keyboardhide', function (event) {
-
   // TODO: Android is having problems
   if (Platform.isAndroid()) {
     return;
   }
 
-  // $('input, textarea').blur();
-  $('body').removeClass('keyboard-open');
+  keyboardHideTimeout = setTimeout(function () {
+    // $('input, textarea').blur();
+    $('body').removeClass('keyboard-open');
 
-  // Detach any elements that were attached
-  $('[data-keyboard-attach]').each(function (index, el) {
-    $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
-  });
+    // Detach any elements that were attached
+    $('[data-keyboard-attach]').each(function (index, el) {
+      $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
+    });
 
-  // Reset the content area(s)
-  $('.content.overflow-scroll').each(function (index, el) {
-    $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
-  });
+    // Reset the content area(s)
+    $('.content.overflow-scroll').each(function (index, el) {
+      $(el).css({bottom: $(el).data('ionkeyboard.bottom')});
+    });
+
+  }, 50);
+
 
 });

--- a/components/ionNavBackButton/ionNavBackButton.js
+++ b/components/ionNavBackButton/ionNavBackButton.js
@@ -1,7 +1,8 @@
 IonScrollPositions = {};
 
 Router.onStop(function () {
-  IonScrollPositions[this.route.path(this.params)] = $('.overflow-scroll').scrollTop();
+  if (this && this.route && this.route.path)
+    IonScrollPositions[this.route.path(this.params)] = $('.overflow-scroll').scrollTop();
 });
 
 Template.ionNavBackButton.events({
@@ -10,7 +11,7 @@ Template.ionNavBackButton.events({
     $('[data-navbar-container]').addClass('nav-bar-direction-back');
     
     //get most up-to-date url, if it exists
-    backUrl = template.getBackUrl()
+    backUrl = template.getBackUrl();
     if (backUrl) {
       Router.go(backUrl);
     } else {

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -64,7 +64,7 @@ IonPopup = {
       templateName: options.templateName,
       buttons: [
         {
-          text: options.cancelText ? options.cancelText : 'Cancel',
+          text: options.cancelText ? options.cancelText : 'Annuler',
           type: options.cancelType ? options.cancelType : 'button-default',
           onTap: function (event, template) {
             if (options.onCancel) options.onCancel(event, template);

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  'ionic-plugin-keyboard': '1.0.8'
+  'cordova-plugin-keyboard': '1.1.3'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
To reproduce issue:

On a long page, add at least two inputs near the bottom of the page, make sure the keyboard would cover them when opened. Clicking one input after another would make the page jump.

To fix this issue, I added a timeout of 50 ms to see if the keyboard is reopening in a short amount of time. if so, cancel the resize.
