### PR TITLE
IonPopup - add cssClass, IonPopup.show etc now returns a handle to close individual popups, scope bug with multiple popups fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build*
+.idea*
 .DS_Store

--- a/components/ionPopup/ionPopup.html
+++ b/components/ionPopup/ionPopup.html
@@ -1,7 +1,7 @@
 <template name="ionPopup">
   <div class="backdrop">
     <div class="popup-container">
-      <div class="popup">
+      <div class="popup {{cssClass}}">
         {{#if hasHead}}
           <div class="popup-head">
             {{#if title}}

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -25,7 +25,8 @@ IonPopup = {
       title: options.title,
       subTitle: options.subTitle,
       buttons: this.buttons,
-      template: innerTemplate
+      template: innerTemplate,
+      cssClass: options.cssClass || ''
     };
 
     this.view = Blaze.renderWithData(this.template, data, $('.ionic-body').get(0));

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -45,7 +45,7 @@ IonPopup = {
   },
 
   alert: function (options) {
-    IonPopup.show({
+    return IonPopup.show({
       title: options.title,
       subTitle: options.subTitle,
       template: options.template,
@@ -64,7 +64,7 @@ IonPopup = {
   },
 
   confirm: function (options) {
-    IonPopup.show({
+    return IonPopup.show({
       title: options.title,
       subTitle: options.subTitle,
       template: options.template,
@@ -104,7 +104,7 @@ IonPopup = {
     template += '<input type="' + options.inputType + '" placeholder="' +
       options.inputPlaceholder + '" name="prompt" >';
 
-    IonPopup.show({
+    return IonPopup.show({
       title: options.title,
       subTitle: options.subTitle,
       template: template,

--- a/components/ionPopup/ionPopup.js
+++ b/components/ionPopup/ionPopup.js
@@ -36,6 +36,12 @@ IonPopup = {
     $backdrop.addClass('visible active');
     var $popup = $backdrop.find('.popup-container');
     $popup.addClass('popup-showing active');
+
+    return {
+      close: function(){
+        Blaze.remove( this.view )
+      }.bind( this )
+    }
   },
 
   alert: function (options) {
@@ -167,7 +173,7 @@ Template.ionPopup.events({
 
   'click [data-index]': function (event, template) {
     var index = $(event.target).data('index');
-    IonPopup.buttonClicked(index, event, template);
+    IonPopup.buttonClicked.call( template.data, index, event, template);
   }
 
 });


### PR DESCRIPTION
- IonicPopup - add cssClass option which is supported in official Ionic Framework

- IonicPopup - return a handle with a close function, to allow closing individual IonPopups

- IonicPopup - fixed a bug on IonPopup.buttonClicked, this is the `.call` in the buttonClicked, not referencing the correct popup in cases where there are multiple popups. This is reproducible if you show a two button popup, then within the onTap, you were to show a single button popup. After you close the "second" single button popup. In the onTap, of the first popup, `this` still references the second popup.

This should allow using multiple nested popups, e.g.

```coffeescript
IonPopup.show({
      title: 'Forgotten Password'
      template: "..."
      // example of cssClass usage
      cssClass: 'popup-wide popup-forgot-password'
      buttons: [{
        text: 'Cancel'
        type: 'button-default'
        onTap: ( ev, t) ->
          return true;
      },
      {
        text: 'Submit'
        type: 'button-positive'
        onTap: ( ev, t ) ->

          resetEmail = $('#forgot_password_container .forgotten-password-email').val()

          # we force all emails to be lowercase and no spaces
          resetEmail = resetEmail.replace(/[ ]/g, '').toLowerCase()

          unless resetEmail?.length
            // example of support for closing of individual popups
            subNoEmailPopup = IonPopup.show(
              template: 'You must enter an email'
              buttons: [{
                text: 'Ok'
                type: 'button-default'
                onTap: ( ev, t ) ->
                  subNoEmailPopup.close()
              }]
            )
```