### PR TITLE
Prevent from the 'native.keyboardhide' event handler to execute twice

### DIFF
--- a/components/ionKeyboard/ionKeyboard.js
+++ b/components/ionKeyboard/ionKeyboard.js
@@ -72,7 +72,7 @@ window.addEventListener('native.keyboardshow', function (event) {
 window.addEventListener('native.keyboardhide', function (event) {
 
   // TODO: Android is having problems
-  if (Platform.isAndroid()) {
+  if (Platform.isAndroid() || $(body).hasClass('keyboard-open')) {
     return;
   }
 


### PR DESCRIPTION
Prevent from the 'native.keyboardhide' event handler to execute twice and store the wrong bottom value for when the keyboard hides.
